### PR TITLE
update Prometheus remote write sync

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -64,7 +64,7 @@ details. This section summarizes a few key differences.
 * Collector will support all global, discovery and scraping configuration
   options in the Prometheus server. Collector will ignore the
   alerting rules.
-* Collector MUST pass the [Prometheus Remote Write Compliance Tests](https://github.com/prometheus/compliance/tree/main/remote_write).
+* Collector MUST pass the [Prometheus Remote Write Sender Compliance Tests](https://github.com/prometheus/compliance/tree/main/remote_write_sender).
 * Collector will support exporting cumulative series to
   OTLP-compatible exporters.
 * Collector won’t assume any OpenTelemetry semantic conventions


### PR DESCRIPTION
It looks like since the spec was written, the Prometheus remote write tests split into sender-side and receiver-side. I believe the sender-side ones are the relevant ones.